### PR TITLE
feat: update poetry installer URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,6 @@ runs:
   steps:
     - name: Install and configure Poetry
       run: |
-        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - --yes --version=${{ inputs.version }}
+        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - --yes --version=${{ inputs.version }}
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       shell: bash


### PR DESCRIPTION
Update the source URL for Poetry's installation script. It's required to install the latest Poetry versions.